### PR TITLE
Client Secrets Load Fix

### DIFF
--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -170,8 +170,11 @@ def process_args():
                 LOGGER.critical("tap-google-analytics: The JSON definition in '{}' has errors".format(args.config['key_file_location']))
                 sys.exit(1)
         else:
-            LOGGER.critical("tap-google-analytics: '{}' file not found".format(args.config['key_file_location']))
-            sys.exit(1)
+            if args.config.get('key_file_location').is_dict():
+                args.config['client_secrets'] = args.config['key_file_location']
+            else:
+                LOGGER.critical("tap-google-analytics: '{}' file not found".format(args.config['key_file_location']))
+                sys.exit(1)
     else:
         # If using oauth credentials, verify that all required keys are present
         credentials = args.config['oauth_credentials']

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -166,12 +166,14 @@ def process_args():
         if Path(args.config['key_file_location']).is_file():
             try:
                 args.config['client_secrets'] = load_json(args.config['key_file_location'])
+                LOGGER.info('Client Secrets loaded in from File')
             except ValueError:
                 LOGGER.critical("tap-google-analytics: The JSON definition in '{}' has errors".format(args.config['key_file_location']))
                 sys.exit(1)
         else:
             if args.config.get('key_file_location').is_dict():
                 args.config['client_secrets'] = args.config['key_file_location']
+                LOGGER.info('Client Secrets loaded in from dict')
             else:
                 LOGGER.critical("tap-google-analytics: '{}' file not found".format(args.config['key_file_location']))
                 sys.exit(1)

--- a/tap_google_analytics/__init__.py
+++ b/tap_google_analytics/__init__.py
@@ -174,6 +174,9 @@ def process_args():
             if args.config.get('key_file_location').is_dict():
                 args.config['client_secrets'] = args.config['key_file_location']
                 LOGGER.info('Client Secrets loaded in from dict')
+            elif args.config.get('key_file_location').is_json():
+                args.config['client_secrets'] = json.load(args.config['key_file_location'])
+                LOGGER.info('Client Secrets loaded in from JSON')
             else:
                 LOGGER.critical("tap-google-analytics: '{}' file not found".format(args.config['key_file_location']))
                 sys.exit(1)


### PR DESCRIPTION
Client Secrets is originally loaded into as a File.  With Kubernetes it comes through as something else. There is now a check for if the payload comes through as a file, a dictionary, or a json string, with appropriate logging for each.